### PR TITLE
Use core version of Hive-exec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val paradiseVersion = "2.1.0"
 
 val scaldingVersion = "0.15.0"
 val parquetVersion = "1.6.0rc7"
-val hiveExecVersion = "0.10.0"
+val hiveExecVersion = "1.1.0"
 val jodaTimeVersion = "2.8.1"
 val jodaConvertVersion = "1.7"
 
@@ -121,7 +121,7 @@ lazy val scalding = (project in file("scalding")).
       "com.twitter" %% "scalding-parquet" % scaldingVersion,
       "com.twitter" % "parquet-column" % parquetVersion,
       "com.twitter" % "parquet-hadoop" % parquetVersion,
-      "org.apache.hive" % "hive-exec" % hiveExecVersion exclude("com.google.protobuf", "protobuf-java") exclude("org.apache.avro", "avro-mapred")
+      "org.apache.hive" % "hive-exec" % hiveExecVersion classifier "core" exclude("com.google.protobuf", "protobuf-java") exclude("org.apache.avro", "avro-mapred")
     )
   ).dependsOn(core)
 

--- a/scalding/src/main/scala/com/criteo/scalaschemas/scalding/tuple/scheme/RcfileScheme.scala
+++ b/scalding/src/main/scala/com/criteo/scalaschemas/scalding/tuple/scheme/RcfileScheme.scala
@@ -186,8 +186,8 @@ class RcfileScheme(columns: Seq[RcfileColumn])
       colValRefs(i) = new BytesRefWritable
       rowWritable.set(i, colValRefs(i))
       sinkField(byteStream, tuple.getObject(i), tuple.getTypes()(i))
-      colValRefs(i).set(byteStream.getData, startPos, byteStream.getCount - startPos)
-      startPos = byteStream.getCount
+      colValRefs(i).set(byteStream.getData, startPos, byteStream.size() - startPos)
+      startPos = byteStream.size()
     }
 
     sinkCall.getOutput.collect(null, rowWritable)


### PR DESCRIPTION
Use core version of Hive-exec instead of the uber jar that is packaging
a lot of external dependencies.