### PR TITLE
Add strict param to OsvSources

### DIFF
--- a/scalding/src/main/scala/com/criteo/scalaschemas/scalding/tuple/sources/MultiplePartitionDelimitedSchemeSource.scala
+++ b/scalding/src/main/scala/com/criteo/scalaschemas/scalding/tuple/sources/MultiplePartitionDelimitedSchemeSource.scala
@@ -1,0 +1,15 @@
+package com.criteo.scalaschemas.scalding.tuple.sources
+
+import cascading.tap.SinkMode
+import cascading.tuple.Fields
+import com.twitter.scalding.{DelimitedScheme, FixedPathSource, Source}
+
+case class MultiplePartitionDelimitedSchemeSource(p: Seq[String],
+                                                  override val fields: Fields = Fields.ALL,
+                                                  override val sinkMode: SinkMode = SinkMode.REPLACE,
+                                                  override val strict: Boolean = false,
+                                                  override val separator: String = "\t"
+                                                 ) extends FixedPathSource(p: _*) with DelimitedScheme {
+
+}
+

--- a/scalding/src/main/scala/com/criteo/scalaschemas/scalding/tuple/sources/OsvSources.scala
+++ b/scalding/src/main/scala/com/criteo/scalaschemas/scalding/tuple/sources/OsvSources.scala
@@ -9,15 +9,15 @@ import com.twitter.scalding.{DelimitedScheme, FixedPathSource, Source}
 trait OsvSources[T, K] {
   self: ScaldingType[T, K] =>
 
-  override def sink(partitionKey: K): Source = MultiplePartitionOsv(partitions(partitionKey))
+  val strict: Boolean = false
 
-  override def source(partitionKey: K): Source = MultiplePartitionOsv(partitions(partitionKey), fields)
+  override def sink(partitionKey: K): Source = MultiplePartitionDelimitedSchemeSource(partitions(partitionKey),
+    strict = strict,
+    separator = "\1")
 
-}
+  override def source(partitionKey: K): Source = MultiplePartitionDelimitedSchemeSource(partitions(partitionKey),
+    fields,
+    strict = strict,
+    separator = "\1")
 
-case class MultiplePartitionOsv(p: Seq[String],
-                                override val fields: Fields = Fields.ALL,
-                                override val sinkMode: SinkMode = SinkMode.REPLACE
-                               ) extends FixedPathSource(p: _*) with DelimitedScheme {
-  override val separator = "\1"
 }

--- a/scalding/src/main/scala/com/criteo/scalaschemas/scalding/tuple/sources/TsvSources.scala
+++ b/scalding/src/main/scala/com/criteo/scalaschemas/scalding/tuple/sources/TsvSources.scala
@@ -9,13 +9,13 @@ import com.twitter.scalding.{DelimitedScheme, FixedPathSource, Source}
 trait TsvSources[T, K] {
   self: ScaldingType[T, K] =>
 
-  override def sink(partitionKey: K): Source = MultiplePartitionTsv(partitions(partitionKey))
+  val strict: Boolean = false
 
-  override def source(partitionKey: K): Source = MultiplePartitionTsv(partitions(partitionKey), fields)
+  override def sink(partitionKey: K): Source = MultiplePartitionDelimitedSchemeSource(partitions(partitionKey),
+    strict = strict)
+
+  override def source(partitionKey: K): Source = MultiplePartitionDelimitedSchemeSource(partitions(partitionKey),
+    fields,
+    strict = strict)
 
 }
-
-case class MultiplePartitionTsv(p: Seq[String],
-                                override val fields: Fields = Fields.ALL,
-                                override val sinkMode: SinkMode = SinkMode.REPLACE
-                               ) extends FixedPathSource(p: _*) with DelimitedScheme


### PR DESCRIPTION
This is useful for schema evolution. For example if we add a new field in a ScaldingType model we will be able to use the new code to read older files. In this case the value of the new field will be the default set in the ScaldingType or null in case there is no default.